### PR TITLE
bump to golang 1.5 final and hekad 0.10b1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM golang:1.5beta2
+FROM golang:1.5
 
-ENV HEKAD_VERSION v0.10.0b0
+ENV HEKAD_VERSION v0.10.0b1
 
 RUN apt-get update && \
     apt-get -y upgrade && \


### PR DESCRIPTION
Small bumps of version to golang 1.5 and last release of heka. 

Thanks 
